### PR TITLE
Fix usage of deprecated punch() params

### DIFF
--- a/gravityuse.lua
+++ b/gravityuse.lua
@@ -62,7 +62,7 @@ on_punch=function(self, puncher, time_from_last_punch, tool_capabilities, dir)
 		if self.target and self.target:get_attach() then
 			self.target:set_detach()
 			self.target:set_hp(0)
-			self.target:punch(self.object, {full_punch_interval=1.0,damage_groups={fleshy=4}}, "default:bronze_pick", nil)
+			self.target:punch(self.object, 1, {full_punch_interval=1.0,damage_groups={fleshy=4}})
 		end
 
 end,
@@ -72,7 +72,7 @@ on_step= function(self, dtime)
 		self.timer=0
 		if self.target==nil or (not self.target:get_attach()) then
 			self.object:set_hp(0)
-			self.object:punch(self.object, {full_punch_interval=1.0,damage_groups={fleshy=4}}, "default:bronze_pick", nil)
+			self.object:punch(self.object, 1, {full_punch_interval=1.0,damage_groups={fleshy=4}})
 			if self.sound then minetest.sound_stop(self.sound) end
 		end
 		if self.player then
@@ -152,7 +152,7 @@ on_step= function(self, dtime)
 
 		if self.target==nil or (not self.target:get_attach()) then
 			self.object:set_hp(0)
-			self.object:punch(self.object, {full_punch_interval=1.0,damage_groups={fleshy=4}}, "default:bronze_pick", nil)
+			self.object:punch(self.object, 1, {full_punch_interval=1.0,damage_groups={fleshy=4}})
 			return self
 		end
 		return self

--- a/init.lua
+++ b/init.lua
@@ -54,11 +54,11 @@ function portal_delete(name,n)	-- using set_hp & :punch instand of :remove ... n
 	if (n==1 or n==0) and portalgun_portal[name].portal1~=nil then
 		if n==0 then 
 			local pos=portalgun_portal[name].portal1:get_pos()
-			if pos~=nil then minetest.sound_play("portalgun_closeportals", {pos=pos,max_hear_distance = 20, gain = 1}) end
+			if pos ~= nil then minetest.sound_play("portalgun_closeportals", {pos=pos,max_hear_distance = 20, gain = 1}) end
 		end
 		portalgun_portal[name].portal1_active=false
 		portalgun_portal[name].portal1:set_hp(0)
-		portalgun_portal[name].portal1:punch(portalgun_portal[name].portal1, {full_punch_interval=1.0,damage_groups={fleshy=9000}}, "default:bronze_pick", nil)
+		portalgun_portal[name].portal1:punch(portalgun_portal[name].portal1, 1, {full_punch_interval=1.0,damage_groups={fleshy=9000}})
 	end
 	if (n==2 or n==0) and portalgun_portal[name].portal2~=nil then
 		if n==0 then 
@@ -67,7 +67,7 @@ function portal_delete(name,n)	-- using set_hp & :punch instand of :remove ... n
 		end
 		portalgun_portal[name].portal2_active=false
 		portalgun_portal[name].portal2:set_hp(0)
-		portalgun_portal[name].portal2:punch(portalgun_portal[name].portal2, {full_punch_interval=1.0,damage_groups={fleshy=9000}}, "default:bronze_pick", nil)
+		portalgun_portal[name].portal2:punch(portalgun_portal[name].portal2, 1, {full_punch_interval=1.0,damage_groups={fleshy=9000}})
 	end
 	if n==0 then portalgun_portal[name]=nil end
 end

--- a/powerball.lua
+++ b/powerball.lua
@@ -87,7 +87,7 @@ on_step= function(self, dtime)
 		for i, ob in pairs(minetest.get_objects_inside_radius(pos, 2)) do
 			if ob:is_player() or (ob:get_luaentity() and ob:get_luaentity().portalgun~=1 and ob:get_luaentity().wsc==nil and ob:get_luaentity().powerball~=1) then
 				ob:set_hp(0)
-				ob:punch(ob, {full_punch_interval=1.0,damage_groups={fleshy=9000}}, "default:bronze_pick", nil)
+				ob:punch(ob, 1, {full_punch_interval=1.0,damage_groups={fleshy=9000}})
 
 			end
 		end
@@ -101,7 +101,7 @@ on_step= function(self, dtime)
 		if self.timer2>40 then
 			minetest.sound_stop(self.sound)
 			self.object:set_hp(0)
-			self.object:punch(self.object, {full_punch_interval=1.0,damage_groups={fleshy=9000}}, "default:bronze_pick", nil)
+			self.object:punch(self.object, 1, {full_punch_interval=1.0,damage_groups={fleshy=9000}})
 			return self
 		end
 		local v=self.object:get_velocity()

--- a/stuff.lua
+++ b/stuff.lua
@@ -301,7 +301,7 @@ on_use = function(itemstack, user, pointed_thing)
 	for ii, ob in pairs(minetest.get_objects_inside_radius(pos, 7)) do
 		if ob:get_luaentity() then
 			ob:set_hp(0)
-			ob:punch(ob, {full_punch_interval=1.0,damage_groups={fleshy=9000}}, "default:bronze_pick", nil)
+			ob:punch(ob, 1, {full_punch_interval=1.0,damage_groups={fleshy=9000}})
 		end
 	end
 	return itemstack
@@ -508,7 +508,7 @@ on_step= function(self, dtime)
 	for i, ob in pairs(minetest.get_objects_inside_radius(pos, 1.5)) do
 		if  ob:is_player() or (ob:get_luaentity() and ob:get_luaentity().bullet~=1) then
 			ob:set_hp(ob:get_hp()-7)
-			ob:punch(self.object, 1,{full_punch_interval=1.0,damage_groups={fleshy=4}}, "default:bronze_pick", nil)
+			ob:punch(self.object, 1, {full_punch_interval=1.0,damage_groups={fleshy=4}})
 			self.object:remove()
 			return
 		end

--- a/weightedstoragecube.lua
+++ b/weightedstoragecube.lua
@@ -86,7 +86,7 @@ on_step= function(self, dtime)
 				end
 			end
 			self.object:set_hp(0)
-			self.object:punch(self.object, 1, "default:bronze_pick", nil)
+			self.object:punch(self.object, 1)
 		end
 	end,
 	timer=0,
@@ -333,7 +333,7 @@ minetest.register_node("portalgun:objdestroyer_1", {
 			for i, ob in pairs(minetest.get_objects_inside_radius(pos, 5)) do
 				if ob:get_luaentity() then
 					ob:set_hp(0)
-					ob:punch(ob, {full_punch_interval=1.0,damage_groups={fleshy=9000}}, "default:bronze_pick", nil)
+					ob:punch(ob, 1, {full_punch_interval=1.0,damage_groups={fleshy=9000}})
 				end
 			end
 		end


### PR DESCRIPTION
What the title says. The params for the frequently used punch() function are all outdated and cause frequent crashes. This PR fixes that.